### PR TITLE
[servicemanager] Move configs and rootfs to dedicated path

### DIFF
--- a/imageunpacker/serviceimage.go
+++ b/imageunpacker/serviceimage.go
@@ -99,6 +99,23 @@ func (unpacker *ImageUnpacker) serviceUnpack(archivePath string) (string, error)
 		return "", err
 	}
 
+	imageParts, err := getImageParts(imagePath)
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.Rename(imageParts.ImageConfigPath, filepath.Join(imagePath, "image.json")); err != nil {
+		return "", err
+	}
+
+	if err := os.Rename(imageParts.ServiceConfigPath, filepath.Join(imagePath, "service.json")); err != nil {
+		return "", err
+	}
+
+	if err := os.Rename(imageParts.ServiceFSPath, filepath.Join(imagePath, "rootfs")); err != nil {
+		return "", err
+	}
+
 	log.WithFields(log.Fields{
 		"imagePath": imagePath,
 	}).Debug("Service image unpacked")


### PR DESCRIPTION
This is WA to do not calculate digests on zephyr dom0.